### PR TITLE
Build Boost.NumPy as different packages per different Python major versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 sudo: required
 dist: trusty
-language: cpp
+language: python
 
 python:
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ python:
   - "3.4"
 
 before_install:
-  - export PATH=$(echo $PATH | tr ':' "\n" | sed '/\/opt\/python/d' | tr "\n" ":" | sed "s|::|:|g")
   - sudo apt-get -qq update
   - sudo apt-get install -y libboost-python-dev python-numpy python3-numpy libpython-dev libpython3-dev python-sphinx
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,11 +76,21 @@ endif()
 # In some cases, you may need to explicitly specify that a dynamic Boost is used; if so use:
 # add_definitions( -DBOOST_ALL_DYN_LINK )
 
-# Variable controlling whether the boost_numpy is a shared or static library.
-if (WIN32)
-  set(LIBRARY_TYPE STATIC CACHE STRING "type of library to make for boost_numpy")
+# We use different target names for Python 2 and 3 to enable to install
+# boost_numpy for both of Python 2 and 3.
+if(${PYTHON_VERSION_STRING} GREATER 3.0)
+  set(boost_numpy_target boost_python3_numpy)
+  set(boost_numpy_package BoostPython3Numpy)
 else()
-  set(LIBRARY_TYPE SHARED CACHE STRING "type of library to make for boost_numpy")
+  set(boost_numpy_target boost_python2_numpy)
+  set(boost_numpy_package BoostPython2Numpy)
+endif()
+
+# Variable controlling whether the ${boost_numpy_target} is a shared or static library.
+if (WIN32)
+  set(LIBRARY_TYPE STATIC CACHE STRING "type of library to make for ${boost_numpy_target}")
+else()
+  set(LIBRARY_TYPE SHARED CACHE STRING "type of library to make for ${boost_numpy_target}")
 endif()
 
 # Variable controlling building of documentation.
@@ -164,21 +174,21 @@ set(LIB_INSTALL_DIR lib/ CACHE PATH
 
 include(CMakePackageConfigHelpers)
 configure_package_config_file(cmake/BoostNumpyConfig.cmake.in
-    ${CMAKE_CURRENT_BINARY_DIR}/BoostNumpyConfig.cmake
-    INSTALL_DESTINATION ${LIB_INSTALL_DIR}/BoostNumpy/cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/${boost_numpy_package}Config.cmake
+    INSTALL_DESTINATION ${LIB_INSTALL_DIR}/${boost_numpy_package}/cmake
     PATH_VARS INCLUDE_INSTALL_DIR LIB_INSTALL_DIR)
 write_basic_package_version_file(
-    ${CMAKE_CURRENT_BINARY_DIR}/BoostNumpyConfigVersion.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/${boost_numpy_package}ConfigVersion.cmake
     VERSION 0.24.0
     COMPATIBILITY SameMajorVersion)
 
-install(EXPORT "${PROJECT_NAME}Targets"
-        FILE "BoostNumpyTargets.cmake"
-        DESTINATION "${LIB_INSTALL_DIR}/BoostNumpy/cmake")
+install(EXPORT "${boost_numpy_target}Targets"
+        FILE "${boost_numpy_package}Targets.cmake"
+        DESTINATION "${LIB_INSTALL_DIR}/${boost_numpy_package}/cmake")
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/BoostNumpyConfig.cmake
-              ${CMAKE_CURRENT_BINARY_DIR}/BoostNumpyConfigVersion.cmake
-        DESTINATION ${LIB_INSTALL_DIR}/BoostNumpy/cmake)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${boost_numpy_package}Config.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/${boost_numpy_package}ConfigVersion.cmake
+        DESTINATION ${LIB_INSTALL_DIR}/${boost_numpy_package}/cmake)
 
 # Building a package with CPack.
 set(CPACK_PACKAGE_NAME boost-numpy)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,8 +76,8 @@ endif()
 # In some cases, you may need to explicitly specify that a dynamic Boost is used; if so use:
 # add_definitions( -DBOOST_ALL_DYN_LINK )
 
-# We use different target names for Python 2 and 3 to enable to install
-# boost_numpy for both of Python 2 and 3.
+# We build Boost.NumPy as different package per different Python major version
+# (2 or 3) to enable to install two Boost.NumPy packages of Python 2 and 3.
 if(${PYTHON_VERSION_STRING} GREATER 3.0)
   set(boost_numpy_target boost_python3_numpy)
   set(boost_numpy_package BoostPython3Numpy)

--- a/cmake/BoostNumpyConfig.cmake.in
+++ b/cmake/BoostNumpyConfig.cmake.in
@@ -5,4 +5,4 @@ set(BoostNumpy_VERSION x.y.z)
 set_and_check(BoostNumpy_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
 set(BoostNumpy_INCLUDE_DIRS ${BoostNumpy_INCLUDE_DIR})
 
-include("${CMAKE_CURRENT_LIST_DIR}/BoostNumpyTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/@boost_numpy_package@Targets.cmake")

--- a/libs/numpy/example/CMakeLists.txt
+++ b/libs/numpy/example/CMakeLists.txt
@@ -2,8 +2,8 @@
 macro( addPythonExe _name _srccpp )
   ADD_EXECUTABLE(${_name} ${_srccpp})
   
-  # make the pyd library link against boost_numpy python and boost
-  TARGET_LINK_LIBRARIES(${_name} boost_numpy)
+  # make the pyd library link against ${boost_numpy_target} python and boost
+  TARGET_LINK_LIBRARIES(${_name} ${boost_numpy_target})
   
   # put the example target into a VS solution folder named example (should
   # be a no-op for Linux)
@@ -13,8 +13,8 @@ endmacro()
 macro( addPythonMod _name _srccpp )
   PYTHON_ADD_MODULE(${_name} ${_srccpp})
   
-  # make the pyd library link against boost_numpy python and boost
-  TARGET_LINK_LIBRARIES(${_name} boost_numpy)
+  # make the pyd library link against ${boost_numpy_target} python and boost
+  TARGET_LINK_LIBRARIES(${_name} ${boost_numpy_target})
   
   # put the example target into a VS solution folder named example (should
   # be a no-op for Linux)

--- a/libs/numpy/src/CMakeLists.txt
+++ b/libs/numpy/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_library(boost_numpy ${LIBRARY_TYPE}
+add_library(${boost_numpy_target} ${LIBRARY_TYPE}
   # header files
   ../../../boost/numpy/dtype.hpp
   ../../../boost/numpy/internal.hpp
@@ -17,13 +17,13 @@ add_library(boost_numpy ${LIBRARY_TYPE}
   ufunc.cpp
   numpy.cpp
 )
-target_link_libraries(boost_numpy
+target_link_libraries(${boost_numpy_target}
   ${Boost_LIBRARIES}
   ${PYTHON_LIBRARIES}
 )
 
-install(TARGETS boost_numpy 
-  EXPORT "${PROJECT_NAME}Targets"
+install(TARGETS ${boost_numpy_target}
+  EXPORT "${boost_numpy_target}Targets"
   ARCHIVE DESTINATION lib${LIB_SUFFIX}
   LIBRARY DESTINATION lib${LIB_SUFFIX}
   PERMISSIONS OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE

--- a/libs/numpy/test/CMakeLists.txt
+++ b/libs/numpy/test/CMakeLists.txt
@@ -24,8 +24,8 @@ macro( addPythonTest _name _srcpy )
     ${CMAKE_CURRENT_BINARY_DIR}/${_srcpy}
   )
 
-  # make the pyd library link against boost_numpy python and boost
-  TARGET_LINK_LIBRARIES(${_name} boost_numpy)
+  # make the pyd library link against ${boost_numpy_target} python and boost
+  TARGET_LINK_LIBRARIES(${_name} ${boost_numpy_target})
 
   # make a test of the module using the python source file in the test directory
   ADD_TEST(${_name} ${TestCommand} ${CMAKE_CURRENT_BINARY_DIR}/${_srcpy})


### PR DESCRIPTION
This is necessary to install two versions of Boost.NumPy for Python 2 and 3 side by side. Noost.NumPy dependent packages now should find them as
```cmake
find_package(BoostPython2Numpy) # for Python 2
find_package(BoostPython3Numpy) # for Python 3
```

This is a stopgap solution until we use Boost 1.63; Boost.Numpy will be shipped with Boost.Python from 1.63.